### PR TITLE
Big update, more in actual PR

### DIFF
--- a/encryption.py
+++ b/encryption.py
@@ -1,64 +1,81 @@
+# Cryptography imports beep beep boop yu2hakme. 
 from cryptography.fernet import Fernet
-import Path
+from cryptography.fernet import InvalidToken
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.backends import default_backend
+from cryptography.fernet import Fernet
+
+# Basic imports 
+import base64
+import os
 import yaml
 
-# Generate a key and write it to a file (do this only once)
-def write_key():
-    key = Fernet.generate_key()
-    with open("secret.key", "wb") as key_file:
-        key_file.write(key)
+# From Imports 
+from getpass import getpass
+from pathlib import Path
 
-# Function to load the key from the secret file
-def load_key():
-    return open("secret.key", "rb").read()
+def derive_key_from_password(password, salt):
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        iterations=100000,
+        backend=default_backend()
+    )
+    key = base64.urlsafe_b64encode(kdf.derive(password.encode()))
+    return key 
 
-# Encrypt the YAML file
-def encrypt_file(file_path, key):
+def encrypt_file_with_password(file_path, password):
+    salt = os.urandom(16)  # Generate a new salt
+    key = derive_key_from_password(password, salt)
     fernet = Fernet(key)
-    with open(file_path, 'rb') as file:
-        original = file.read()
-
-    encrypted = fernet.encrypt(original)
-
-    with open("encrypted_yaml.yaml", 'wb') as encrypted_file:
-        encrypted_file.write(encrypted)
-
-# Uncomment to create the key file
-# write_key()
-
-key = load_key()
-encrypt_file("your_yaml_file.yaml", key)
-
-# Load the key
-def load_key():
-    return open("secret.key", "rb").read()
-
-# Decrypt the YAML file
-def decrypt_file(file_path, key):
-    fernet = Fernet(key)
-    with open(file_path, 'rb') as encrypted_file:
-        encrypted = encrypted_file.read()
-
-    decrypted = fernet.decrypt(encrypted)
-
-    return yaml.safe_load(decrypted.decode())
-
-# Load the key
-key = load_key()
-
-# Decrypt and parse the YAML file
-decrypted_data = decrypt_file("encrypted_yaml.yaml", key)
-
-# Assign variables from the YAML data
-your_variable = decrypted_data['your_key']
-
-print(decrypted_data)  # Display the decrypted YAML content
-print(f"Assigned Variable: {your_variable}")
-
-
-def setup():
-
-    path_to_key = Path("Users/cal/Desktop/schwab-stinky.yaml")
-    if path_to_key.is_file():
-        print("fuuuhhhrrrrrrr")
     
+    with open(file_path, 'rb') as file:
+        original_data = file.read()
+    
+    encrypted_data = fernet.encrypt(original_data)
+    
+    # Write the salt and encrypted data to a new file
+    with open(file_path, 'wb') as encrypted_file:
+        encrypted_file.write(salt + encrypted_data)
+
+def decrypt_file_with_password(file_path, password):
+    try:
+        with open(file_path, 'rb') as encrypted_file:
+            # First 16 bytes are the salt
+            salt = encrypted_file.read(16)
+            encrypted_data = encrypted_file.read()
+        
+        key = derive_key_from_password(password, salt)
+        fernet = Fernet(key)
+        
+        decrypted_data = fernet.decrypt(encrypted_data)
+        return yaml.safe_load(decrypted_data.decode())
+    except InvalidToken:
+        print("Uh oh, looks like your encryption password was wrong. \n" 
+              "If you forget this it's okay to just blowaway the credentials, use --startup. and redo the schwab login.")
+        return None
+
+def is_file_encrypted(file_path):
+    if not os.path.isfile(file_path):
+        return False
+    with open(file_path, 'rb') as file:
+        file_header = file.read(16)  # Read the first 16 bytes (the salt size)
+    return len(file_header) == 16  # If there are 16 bytes, it's likely encrypted
+
+# Call to set encryption of both schwab and token.
+def set_encryption(file_path):
+    password = getpass("Enter encryption password to secure schwab-credentials and schwab-tokens.")
+    # We will have finite schwab.yaml files so its okay to just pass these two in. 
+    app_path = os.path.join(file_path, "schwab-credentials.yaml")
+    token_path = os.path.join(file_path, "tokens.yaml")
+    encrypt_file_with_password(app_path, password)
+    encrypt_file_with_password(token_path, password)
+
+def retrieve_encrypted_data(file_path):
+    password = getpass("Enter the encryption password.")
+    token_path = os.path.join(file_path, "tokens.yaml")
+    decrypted_data = decrypt_file_with_password(token_path, password)
+    # Just a print to test if data is corrently decrypted.
+    #print(decrypted_data)


### PR DESCRIPTION
Big Update. 

1) I added file path generation and existence checks. program now stores creds in ~/.schwab-auto-trader.

2) Credentials are encrypted safely with a pass+salt+SHA256 key. Schwab-credentials stores the app secret and key. and the tokens.yaml stores the schwab access_token and refresh_token. Password input required for initial launch of the app and subsequence access for token refreshes. Might have to pull out the tokens if the password prompt keeps being required, but it should be able to sit in an environmental variable safely. 